### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ and speakers at this conference, this package is for you.
 The output for the second command looks like:
 
     Kutmon et al. WikiPathways: capturing the full diversity of pathway knowle...
-    http://dx.doi.org/10.1093/nar/gkv1024 … #example
+    https://doi.org/10.1093/nar/gkv1024 … #example
 

--- a/conferenceR/R/tweetPaper.R
+++ b/conferenceR/R/tweetPaper.R
@@ -4,7 +4,7 @@ tweetPaper = function(doi=NULL, hashtag=NULL) {
     paste(
       info$author[[1]]$family, " et al. \"",
       substr(info$title, 0, 60), "...\" ",
-      "http://dx.doi.org/", info$DOI, " #", hashtag, sep=""
+      "https://doi.org/", info$DOI, " #", hashtag, sep=""
     )
   )
 }


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by changing all static DOI links, as well as code that generates new ones.

Cheers :-)